### PR TITLE
Add variable to set docker URL

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,12 +53,7 @@ These steps assume you are using OpenStack as your cloud service provider but th
         cp <JSON key file location> gcloud-key.json
         ```
 
-3. Download or create a `clouds.yaml` file with your OpenStack cloud credentials. The cloud entry you want to use needs to be named `openstack`. It will be used to allocate the resources for the clusters. Copy the `clouds.yaml` file to the root of the repository.
-   ```
-   cp <clouds.yaml location> .
-   ```
-
-4. If you have already created a SAML service provider on a different server but with the same FQDN, you can use the same certificates and keys. If this is a new setup, skip this step.
+3. If you have already created a SAML service provider on a different server but with the same FQDN, you can use the same certificates and keys. If this is a new setup, skip this step.
 
     Create a directory named `shibboleth-crypto` at the root of the project directory.
 

--- a/site.yaml
+++ b/site.yaml
@@ -146,6 +146,11 @@
             path: "/home/{{ ansible_user }}/mc-hub/credentials"
             state: directory
             mode: "0700"
+        - name: Create the MC Hub Terraform plugin-cache directory
+          file:
+            path: "/home/{{ ansible_user }}/mc-hub/plugin-cache"
+            state: directory
+            mode: "0700"
         - name: Copy the OpenStack configuration file
           copy:
             src: "{{ inventory_dir }}/clouds.yaml"
@@ -184,6 +189,7 @@
           - /home/{{ ansible_user }}/mc-hub/credentials:/home/mcu/credentials
           - /home/{{ ansible_user }}/mc-hub/clusters:/home/mcu/clusters
           - /home/{{ ansible_user }}/mc-hub/database:/home/mcu/database
+          - /home/{{ ansible_user }}/mc-hub/plugin-cache:/home/mcu/.terraform.d/plugin-cache
         userns: keep-id
         workdir: /home/mcu
       tags:

--- a/site.yaml
+++ b/site.yaml
@@ -151,11 +151,6 @@
             path: "/home/{{ ansible_user }}/mc-hub/plugin-cache"
             state: directory
             mode: "0700"
-        - name: Copy the OpenStack configuration file
-          copy:
-            src: "{{ inventory_dir }}/clouds.yaml"
-            dest: "/home/{{ ansible_user }}/mc-hub/credentials"
-            mode: "0600"
         - name: Copy the MC Hub configuration file
           copy:
             src: "{{ inventory_dir }}/configuration.json"
@@ -180,8 +175,6 @@
         state: started
         env:
           MAGIC_CASTLE_ACME_KEY_PEM: /home/mcu/credentials/acme_key.pem
-          OS_CLIENT_CONFIG_FILE: /home/mcu/credentials/clouds.yaml
-          OS_CLOUD: "{{ default_cloud  }}"
         published_ports:
           - "{{ internal_web_app_port }}:5000"
         volumes:

--- a/site.yaml
+++ b/site.yaml
@@ -1,6 +1,7 @@
 - hosts: all
   vars:
     internal_web_app_port: "5000"
+    mc_hub_image: "{{ mc_hub_image_url | default('docker.io/cmdntrf/mc-hub') }}"
   tasks:
     # Disable SELinux because of issues with podman when mounting file
     - name: Disable SELinux
@@ -171,7 +172,7 @@
     - name: Start the MC Hub container
       containers.podman.podman_container:
         name: mc-hub
-        image: docker.io/cmdntrf/mc-hub:{{ mc_hub_version }}
+        image: "{{ mc_hub_image }}:{{ mc_hub_version }}"
         state: started
         env:
           MAGIC_CASTLE_ACME_KEY_PEM: /home/mcu/credentials/acme_key.pem
@@ -190,7 +191,7 @@
     - name: Start the MC Hub clean-up container
       containers.podman.podman_container:
         name: mc-hub-cleaner
-        image: docker.io/cmdntrf/mc-hub:{{ mc_hub_version }}
+        image: "{{ mc_hub_image }}:{{ mc_hub_version }}"
         restart_policy: always
         state: started
         network_mode: host


### PR DESCRIPTION
Add a variable to set a different docker URL than `docker.io/cmdntrf/mc-hub`. 
This is useful for debugging without pushing a new docker version to the main hub.